### PR TITLE
Implement mergesort.

### DIFF
--- a/arrays/arrays.go
+++ b/arrays/arrays.go
@@ -1,0 +1,52 @@
+package arrays
+
+import (
+	"strconv"
+	"strings"
+)
+
+func ArrayToString(array []int) string {
+	stringArray := []string{}
+	for i := range array {
+		number := array[i]
+		text := strconv.Itoa(number)
+		stringArray = append(stringArray, text)
+	}
+	return "[" + strings.Join(stringArray, " ") + "]"
+}
+
+func MergeSort(array *[]int, indent int) {
+	arr := *array
+	if len(arr) > 1 {
+		mid := len(arr) / 2
+
+		L := make([]int, mid)
+		copy(L[:], arr[:mid])
+		R := make([]int, len(arr)-mid)
+		copy(R[:], arr[mid:])
+		MergeSort(&L, indent+1)
+		MergeSort(&R, indent+1)
+
+		i, j, k := 0, 0, 0
+		for i < len(L) && j < len(R) {
+			if L[i] <= R[j] {
+				arr[k] = L[i]
+				i++
+			} else {
+				arr[k] = R[j]
+				j++
+			}
+			k++
+		}
+		for i < len(L) {
+			arr[k] = L[i]
+			i++
+			k++
+		}
+		for j < len(R) {
+			arr[k] = R[j]
+			j++
+			k++
+		}
+	}
+}

--- a/arrays/arrays_test.go
+++ b/arrays/arrays_test.go
@@ -1,0 +1,15 @@
+package arrays
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMergeSort(t *testing.T) {
+	array := []int{12, 11, 13, 5, 6, 7}
+	mergedArray := array
+
+	MergeSort(&mergedArray, 0)
+	assert.Equal(t, []int{5, 6, 7, 11, 12, 13}, mergedArray)
+}


### PR DESCRIPTION
Note: A slice in Go is just a reference to the underlying array. If you need to rely on the "slice" not changing as you change the underlying array, make the slice into an actual array (or manipulate a copy of the underlying array).