### PR TITLE
Check if a binary tree is a binary search tree

### DIFF
--- a/trees/is_binary_search_tree.go
+++ b/trees/is_binary_search_tree.go
@@ -1,0 +1,33 @@
+package trees
+
+import "cmp"
+
+/*
+Implement a function to check if a binary tree is a binary search tree.
+
+A tree with one node is a binary tree.
+A tree with no nodes is a binary tree.
+
+A tree that has a left node that has a value less than or equal to the root may be a binary tree.
+If it has a left node that is greater, then it is not.
+
+A tree that has a right node that has a value greater than the root may be a binary tree.
+If it has a right node that is less than or equal to the root, then it is not.
+*/
+func IsBinarySearchTree[T cmp.Ordered](root *Node[T]) bool {
+	if root == nil {
+		return true
+	}
+	// let's look at the children before exploring deeper so we can exit early if it is obvious that this
+	// is not a binary search tree
+	if (root.left != nil && root.left.data > root.data) || (root.right != nil && root.right.data <= root.data) {
+		return false
+	}
+	isBstLeft := IsBinarySearchTree(root.left)
+	if !isBstLeft {
+		// return early if it is obvious that the left subtree is not a binary search tree
+		return false
+	}
+	isBstRight := IsBinarySearchTree(root.right)
+	return isBstRight
+}

--- a/trees/is_binary_search_tree_test.go
+++ b/trees/is_binary_search_tree_test.go
@@ -1,0 +1,53 @@
+package trees
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsBinarySearchTreeForNonBst(t *testing.T) {
+	tree := CreateNode(13,
+		CreateNode(6,
+			CreateNode(12,
+				nil,
+				CreateNode(41),
+			),
+			CreateNode(9,
+				nil,
+				CreateNode(10),
+			),
+		),
+		CreateNode(25,
+			CreateNode(18,
+				nil,
+				CreateNode(19),
+			),
+			CreateNode(26),
+		),
+	)
+	assert.False(t, IsBinarySearchTree(tree))
+}
+
+func TestIsBinarySearchTreeForBst(t *testing.T) {
+	tree := CreateNode(13,
+		CreateNode(6,
+			CreateNode(2,
+				nil,
+				CreateNode(4),
+			),
+			CreateNode(9,
+				nil,
+				CreateNode(10),
+			),
+		),
+		CreateNode(25,
+			CreateNode(18,
+				nil,
+				CreateNode(19),
+			),
+			CreateNode(26),
+		),
+	)
+	assert.True(t, IsBinarySearchTree(tree))
+}


### PR DESCRIPTION
A binary tree is a tree that has nodes that have at the most, two children.

A binary search tree is a tree such that its nodes have at the most, two children, and the left child's value is less than or equal to the root's value, and the right child's node is greater to the root's value.

This is true for all nodes as we travel down the tree on the left and the right.